### PR TITLE
Fix/component enum

### DIFF
--- a/src/components/Base/Button/Button.vue
+++ b/src/components/Base/Button/Button.vue
@@ -16,18 +16,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-
-export enum Type {
-  Primary = 'primary',
-  Secondary = 'secondary',
-  Destructive = 'destructive'
-}
-
-export enum Size {
-  Small = 'small',
-  Midium = 'midium',
-  Large = 'large'
-}
+import { oneOf } from '@/utils/utils'
 
 export default Vue.extend({
   props: {
@@ -41,11 +30,13 @@ export default Vue.extend({
     },
     type: {
       type: String,
-      default: Type.Primary
+      default: 'primary',
+      validator: oneOf(['primary', 'secondary', 'destructive'])
     },
     size: {
       type: String,
-      default: Size.Midium
+      default: 'midium',
+      validator: oneOf(['small', 'midium', 'large'])
     },
     autoWidth: {
       type: Boolean,

--- a/src/components/Modules/Movies/Poster/Poster.vue
+++ b/src/components/Modules/Movies/Poster/Poster.vue
@@ -16,14 +16,14 @@
       <div class="detailButton">
         <BaseButton 
           text="Detail" 
-          :size="ButtonSize.Midium"
+          size="midium"
         />
       </div>
       <div class="addListButton">
         <BaseButton 
-          text="My List" 
-          :size="ButtonSize.Midium" 
-          :type="ButtonType.Secondary"
+          text="My List"
+          size="midium"
+          type="secondary"
         />
       </div>
     </div>
@@ -33,15 +33,10 @@
 <script lang="ts">
 import Vue from 'vue'
 import MovieEntity from '@/entities/Movie'
-import BaseButton, {
-  Size as ButtonSize,
-  Type as ButtonType
-} from '@/components/Base/Button'
+import BaseButton from '@/components/Base/Button'
 
 interface IData {
   clientWidth: number
-  ButtonSize: typeof ButtonSize
-  ButtonType: typeof ButtonType
 }
 
 export default Vue.extend({
@@ -60,9 +55,7 @@ export default Vue.extend({
   },
   data(): IData {
     return {
-      clientWidth: 0,
-      ButtonSize,
-      ButtonType
+      clientWidth: 0
     }
   },
   computed: {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,15 @@
+import { PropOptions } from 'vue'
+
 export const range = (min: number, max: number): number[] => {
   const nums: number[] = []
   for (let i = min; i <= max; i += 1) {
     nums.push(i)
   }
   return nums
+}
+
+export const oneOf = (keys: string[]): PropOptions['validator'] => {
+  return value => {
+    return keys.indexOf(value) !== -1
+  }
 }

--- a/test/snapshot/__snapshots__/stories.test.js.snap
+++ b/test/snapshot/__snapshots__/stories.test.js.snap
@@ -281,6 +281,142 @@ exports[`Storyshots components/Modules/Movies/Poster Default 1`] = `
             class="Poster__Image"
             src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
           />
+           
+          <div
+            class="content"
+          >
+            <div
+              class="star"
+            >
+              6.9
+            </div>
+             
+            <div
+              class="genres"
+            >
+              Action, Science Fiction, Comedy, Adventure
+            </div>
+             
+            <div
+              class="detailButton"
+            >
+              <button
+                class="Button -primary -midium"
+                type="button"
+              >
+                <div
+                  class="Button__Text"
+                >
+                  Detail
+                </div>
+                 
+                <!---->
+              </button>
+            </div>
+             
+            <div
+              class="addListButton"
+            >
+              <button
+                class="Button -secondary -midium"
+                type="button"
+              >
+                <div
+                  class="Button__Text"
+                >
+                  My List
+                </div>
+                 
+                <!---->
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots components/Modules/Movies/Poster Focused 1`] = `
+<div
+  class="Storybook"
+>
+  <div
+    class="StorybookSection"
+  >
+    <div
+      class="StorybookSection__Header"
+    >
+      Poster
+    </div>
+     
+    <div
+      class="StorybookSection__Body"
+    >
+      <div
+        class="wrapper"
+        style="width: 320px;"
+      >
+        <div
+          class="Poster is-focused"
+          style="height: 0px;"
+        >
+          <img
+            alt="Ant-Man and the Wasp"
+            class="Poster__Image"
+            src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
+          />
+           
+          <div
+            class="content"
+          >
+            <div
+              class="star"
+            >
+              6.9
+            </div>
+             
+            <div
+              class="genres"
+            >
+              Action, Science Fiction, Comedy, Adventure
+            </div>
+             
+            <div
+              class="detailButton"
+            >
+              <button
+                class="Button -primary -midium"
+                type="button"
+              >
+                <div
+                  class="Button__Text"
+                >
+                  Detail
+                </div>
+                 
+                <!---->
+              </button>
+            </div>
+             
+            <div
+              class="addListButton"
+            >
+              <button
+                class="Button -secondary -midium"
+                type="button"
+              >
+                <div
+                  class="Button__Text"
+                >
+                  My List
+                </div>
+                 
+                <!---->
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -364,6 +500,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -378,6 +564,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -392,6 +628,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -406,6 +692,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -420,6 +756,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -434,6 +820,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -448,6 +884,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -462,6 +948,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -476,6 +1012,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -490,6 +1076,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -504,6 +1140,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -518,6 +1204,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -532,6 +1268,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -546,6 +1332,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -560,6 +1396,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -574,6 +1460,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -588,6 +1524,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -602,6 +1588,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -616,6 +1652,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -630,6 +1716,56 @@ exports[`Storyshots components/Modules/Movies/PosterList Default 1`] = `
                       class="Poster__Image"
                       src="https://image.tmdb.org/t/p/w600_and_h900_bestv2//rv1AWImgx386ULjcf62VYaW8zSt.jpg"
                     />
+                     
+                    <div
+                      class="content"
+                    >
+                      <div
+                        class="star"
+                      >
+                        6.9
+                      </div>
+                       
+                      <div
+                        class="genres"
+                      >
+                        Action, Science Fiction, Comedy, Adventure
+                      </div>
+                       
+                      <div
+                        class="detailButton"
+                      >
+                        <button
+                          class="Button -primary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            Detail
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                       
+                      <div
+                        class="addListButton"
+                      >
+                        <button
+                          class="Button -secondary -midium"
+                          type="button"
+                        >
+                          <div
+                            class="Button__Text"
+                          >
+                            My List
+                          </div>
+                           
+                          <!---->
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
**Summary**
Since we use [@babel/plugin-transform-typescript](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typescript) to compile TS script on storyshots, `Enum` is no longer available inside Vue component 😭 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All lines for debugging use are removed
- [ ] All tests are passing
- [ ] Lint checks are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Screenshots**

**Other information:**
